### PR TITLE
Fix GitHub Pages deploy and harden CI workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,26 +22,26 @@ jobs:
             matrix:
                 node-version: [22]
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "pnpm"
 
             - name: Install dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Gather lint results
               run: pnpm run lint:report
               continue-on-error: true
 
             - name: Upload lint results
-              uses: ataylorme/eslint-annotate-action@v3
+              uses: ataylorme/eslint-annotate-action@d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9 # 3.0.0
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   report-json: "eslint_report.json"

--- a/.github/workflows/nuxt-deploy.yml
+++ b/.github/workflows/nuxt-deploy.yml
@@ -12,18 +12,18 @@ jobs:
             matrix:
                 node-version: [22]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "pnpm"
-            - run: pnpm install
-            - run: NUXT_APP_BASE_URL=/web/ pnpm dlx nuxt build --preset github_pages
+            - run: pnpm install --frozen-lockfile
+            - run: NUXT_APP_BASE_URL=/web/ pnpm exec nuxt build --preset github_pages
             - name: Upload artifact
-              uses: actions/upload-pages-artifact@v1
+              uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
               with:
                   path: ./.output/public
     # Deployment job
@@ -43,4 +43,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v1
+              uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## What

The GitHub Pages mirror build was failing because `actions/upload-pages-artifact@v1`
transitively depends on the now-deprecated `actions/upload-artifact@v3`, which
GitHub hard-fails. This fixes that and hardens both workflows.

> Context: GitHub Pages is the **secondary mirror** (served at `/web/`); the
> production site is on Cloudflare at the root of `mockbukkit.org`. The
> `NUXT_APP_BASE_URL=/web/` build flag is correct and intentionally unchanged.

## Changes

- **Bump all actions to their latest releases** — fixes the deprecated-artifact
  failure on `upload-pages-artifact` and `deploy-pages`.
- **Pin every action to a full commit SHA** (with a `# vX.Y.Z` comment) so a
  tampered or repointed tag cannot reach CI — supply-chain hardening.
- **`pnpm install --frozen-lockfile`** in both workflows, so CI fails on lockfile
  drift instead of silently resolving new versions.
- **Build with `pnpm exec`** (locked Nuxt from `node_modules`) instead of
  `pnpm dlx`, which fetched a fresh, unpinned Nuxt from the registry.

## Verification

- Both workflow files validated as parseable YAML.
- `pnpm install --frozen-lockfile` confirmed to pass against the committed
  lockfile locally (no pre-existing drift, so this won't red-X the first run).
- Latest versions + SHAs resolved against the GitHub API at authoring time.

## Follow-up (not in this PR)

Nothing currently bumps the new SHA pins (no Renovate config in the repo; Snyk
only covers app deps). Consider adding a `.github/dependabot.yml` for the
`github-actions` ecosystem to keep the digests patched.